### PR TITLE
feat: allow more separators

### DIFF
--- a/example/lib/demo/pinput_templates/filled.dart
+++ b/example/lib/demo/pinput_templates/filled.dart
@@ -44,7 +44,7 @@ class _FilledState extends State<Filled> {
         length: 4,
         controller: controller,
         focusNode: focusNode,
-        separator: Container(
+        separatorBuilder: (index) => Container(
           height: 64,
           width: 1,
           color: Colors.white,

--- a/example/lib/demo/pinput_templates/rounded_with_shadow.dart
+++ b/example/lib/demo/pinput_templates/rounded_with_shadow.dart
@@ -56,7 +56,7 @@ class _RoundedWithShadowState extends State<RoundedWithShadow> {
       controller: controller,
       focusNode: focusNode,
       defaultPinTheme: defaultPinTheme,
-      separator: const SizedBox(width: 16),
+      separatorBuilder: (index) => const SizedBox(width: 16),
       focusedPinTheme: defaultPinTheme.copyWith(
         decoration: BoxDecoration(
           color: Colors.white,

--- a/lib/src/pinput.dart
+++ b/lib/src/pinput.dart
@@ -61,8 +61,7 @@ class Pinput extends StatefulWidget {
     this.controller,
     this.focusNode,
     this.preFilledWidget,
-    this.separatorPositions,
-    this.separator = PinputConstants._defaultSeparator,
+    this.separatorBuilder,
     this.smsCodeMatcher = PinputConstants.defaultSmsCodeMatcher,
     this.senderPhoneNumber,
     this.androidSmsAutofillMethod = AndroidSmsAutofillMethod.none,
@@ -203,11 +202,8 @@ class Pinput extends StatefulWidget {
   /// Widget that is displayed before field submitted.
   final Widget? preFilledWidget;
 
-  /// Sets the positions where the separator should be shown
-  final List<int>? separatorPositions;
-
   /// Builds a Pinput separator
-  final Widget? separator;
+  final Widget Function(int index)? separatorBuilder;
 
   /// Defines how [Pinput] fields are being placed inside [Row]
   final MainAxisAlignment mainAxisAlignment;
@@ -500,9 +496,9 @@ class Pinput extends StatefulWidget {
       DiagnosticsProperty<Widget?>('cursor', cursor, defaultValue: null),
     );
     properties.add(
-      DiagnosticsProperty<Widget?>(
-        'separator',
-        separator,
+      DiagnosticsProperty<Widget Function(int index)?>(
+        'separatorBuilder',
+        separatorBuilder,
         defaultValue: PinputConstants._defaultSeparator,
       ),
     );
@@ -510,13 +506,6 @@ class Pinput extends StatefulWidget {
       DiagnosticsProperty<Widget?>(
         'obscuringWidget',
         obscuringWidget,
-        defaultValue: null,
-      ),
-    );
-    properties.add(
-      DiagnosticsProperty<List<int>?>(
-        'separatorPositions',
-        separatorPositions,
         defaultValue: null,
       ),
     );

--- a/lib/src/pinput_state.dart
+++ b/lib/src/pinput_state.dart
@@ -478,8 +478,7 @@ class _PinputState extends State<Pinput>
   Widget _buildFields() {
     Widget onlyFields() {
       return _SeparatedRaw(
-        separator: widget.separator,
-        separatorPositions: widget.separatorPositions,
+        separatorBuilder: widget.separatorBuilder,
         mainAxisAlignment: widget.mainAxisAlignment,
         children: Iterable<int>.generate(widget.length).map<Widget>((index) {
           return _PinItem(state: this, index: index);

--- a/lib/src/utils/pinput_constants.dart
+++ b/lib/src/utils/pinput_constants.dart
@@ -13,7 +13,6 @@ class PinputConstants {
   /// The default value [Pinput.length]
   static const _defaultLength = 4;
 
-  /// The default value [Pinput.separator]
   static const _defaultSeparator = SizedBox(width: 8);
 
   /// The hidden text under the Pinput

--- a/lib/src/widgets/widgets.dart
+++ b/lib/src/widgets/widgets.dart
@@ -20,32 +20,35 @@ class _PinputFormField extends FormField<String> {
 class _SeparatedRaw extends StatelessWidget {
   final List<Widget> children;
   final MainAxisAlignment mainAxisAlignment;
-  final List<int>? separatorPositions;
-  final Widget? separator;
+  final Widget Function(int index)? separatorBuilder;
 
   const _SeparatedRaw({
     required this.children,
     required this.mainAxisAlignment,
-    this.separator,
-    this.separatorPositions,
+    this.separatorBuilder,
     Key? key,
   }) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
-    if (separator != null) {
-      final actualSeparatorPositions = separatorPositions ??
-          List.generate(children.length - 1, (index) => index + 1)
-              .toList(growable: false);
+    final separators = <Widget>[];
+    separators.addAll(
+      List.generate(
+        children.length - 1,
+        separatorBuilder == null
+            ? (index) => PinputConstants._defaultSeparator
+            : separatorBuilder!,
+      ),
+    );
 
-      final separatorsCount = actualSeparatorPositions.length;
+    final actualSeparatorPositions =
+        List.generate(children.length - 1, (index) => index + 1)
+            .toList(growable: false);
 
-      for (int i = 0; i < separatorsCount; ++i) {
-        final index = i + actualSeparatorPositions[i];
-        if (index <= children.length) {
-          children.insert(index, separator!);
-        }
-      }
+    for (int i = 0; i < separators.length; i++) {
+      final separator = separators[i];
+      final index = i + actualSeparatorPositions[i];
+      children.insert(index, separator);
     }
 
     return Row(


### PR DESCRIPTION
Right now, the `separator` and `separatorPositions` fields only allow one type of separator. 

This PR allows more than one type of separator, perhaps `SizedBox(width: 8)` for position 1, `SizedBox(width: 12)` for position 2, and so on.

